### PR TITLE
fix: use `GetRecords` rather than `GetRecord` to get batch items in Article and Category

### DIFF
--- a/article/infrastructure/repositoryimpl/article.go
+++ b/article/infrastructure/repositoryimpl/article.go
@@ -27,7 +27,7 @@ func (impl *articleRepoImpl) GetArticles(owner cmprimitive.Username) ([]entity.A
 
 	articlesDo := []ArticleDO{}
 
-	if err := impl.GetRecord(&articleDo, &articlesDo); err != nil {
+	if err := impl.GetRecords(&articleDo, &articlesDo); err != nil {
 		return nil, err
 	}
 

--- a/article/infrastructure/repositoryimpl/category.go
+++ b/article/infrastructure/repositoryimpl/category.go
@@ -56,7 +56,7 @@ func (impl *categoryRepoImpl) GetCategoryList(opt cmrepo.PageListOpt) ([]entity.
 func (impl *categoryRepoImpl) GetAllCategoryList() ([]entity.Category, error) {
 	dos := []CategoryDO{}
 
-	if err := impl.GetRecord(&CategoryDO{}, &dos); err != nil {
+	if err := impl.GetRecords(&CategoryDO{}, &dos); err != nil {
 		if cmdmerror.IsNotFound(err) {
 			return []entity.Category{}, nil
 		}


### PR DESCRIPTION
- fix: use `GetRecords` rather than `GetRecord` to get batch items in Article and Category