### PR TITLE
fix: remove size of field `ReadTimes`

### DIFF
--- a/article/infrastructure/repositoryimpl/do.go
+++ b/article/infrastructure/repositoryimpl/do.go
@@ -38,7 +38,7 @@ type ArticleDO struct {
 	Title     string `gorm:"column:title;index:title_index;size:255"`
 	Content   string `gorm:"column:content;type:text;size:40000"`
 	Cover     string `gorm:"column:cover;size:255"`
-	ReadTimes int    `gorm:"column:read_times;size:11"`
+	ReadTimes int    `gorm:"column:read_times"`
 	IsPublish bool   `gorm:"column:is_publish"`
 	IsTop     bool   `gorm:"column:is_top"`
 }

--- a/statistics/infrastructure/repositoryimpl/do.go
+++ b/statistics/infrastructure/repositoryimpl/do.go
@@ -20,7 +20,7 @@ type ArticleDailyVisitsDO struct {
 	gorm.Model
 
 	Total int       `gorm:"column:total"`
-	Date  time.Time `gorm:"colum:date;unique"`
+	Date  time.Time `gorm:"column:date;unique"`
 }
 
 func (do *ArticleDailyVisitsDO) TableName() string {


### PR DESCRIPTION
the type in mysql is `smalint` if we set size = 11 for field `ReadTimes`, so we remove size thus the type go to `bigint` in mysql. `bigint` can express up to `2^63`