### PR TITLE
build(docker): add timezone configuration for Shanghai

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ RUN cd /go/src/github.com/victorzhou123/vicblog && GO111MODULE=on CGO_ENABLED=0 
 FROM alpine:latest
 WORKDIR /opt/app/
 
+# 安装时区包并设置上海时区
+RUN apk update && apk add --no-cache tzdata \ 
+    && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \ 
+    && echo "Asia/Shanghai" > /etc/timezone \ 
+    && rm -rf /var/cache/apk/*
+
 COPY --from=BUILDER /go/src/github.com/victorzhou123/vicblog/vicblog /opt/app
 COPY --from=BUILDER /go/src/github.com/victorzhou123/vicblog/config/config.yaml /opt/app/config/
 


### PR DESCRIPTION
Set Asia/Shanghai as the default timezone in the Docker container by installing tzdata package and configuring the timezone files.